### PR TITLE
Start targets at boot

### DIFF
--- a/files/systemd/targets/webos-bd.target
+++ b/files/systemd/targets/webos-bd.target
@@ -17,3 +17,6 @@
 [Unit]
 Description="%n"
 Wants=nyx-utils.service
+      
+[Install]
+WantedBy=multi-user.target

--- a/files/systemd/targets/webos-cbd.target
+++ b/files/systemd/targets/webos-cbd.target
@@ -18,3 +18,6 @@
 Description="%n"
 Wants=pm-log-daemon.service \
       sleepd.service
+      
+[Install]
+WantedBy=multi-user.target

--- a/files/systemd/targets/webos-dis.target
+++ b/files/systemd/targets/webos-dis.target
@@ -20,3 +20,6 @@ Description="%n"
 # webos
 Wants=configurator-db8.service \
       db8.service
+      
+[Install]
+WantedBy=multi-user.target

--- a/files/systemd/targets/webos-ibd.target
+++ b/files/systemd/targets/webos-ibd.target
@@ -18,6 +18,8 @@
 Description="%n"
 
 # Network Related services
-Wants=webos-connman-adapter.service
-
-Wants=luna-sys-service.service 
+Wants=webos-connman-adapter.service \
+      luna-sys-service.service 
+      
+[Install]
+WantedBy=multi-user.target

--- a/files/systemd/targets/webos-mbd.target
+++ b/files/systemd/targets/webos-mbd.target
@@ -17,3 +17,6 @@
 [Unit]
 Description="%n"
 Wants=
+      
+[Install]
+WantedBy=multi-user.target

--- a/files/systemd/targets/webos-rbd.target
+++ b/files/systemd/targets/webos-rbd.target
@@ -18,3 +18,6 @@
 Description="%n"
 Wants=activitymanager.service \
       configurator-activity.service
+      
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
They are all wanted by multi-user.target, mimmicking bootd's sequence.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>